### PR TITLE
Migrate packs

### DIFF
--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -302,14 +302,22 @@ def migrate(update: Update, context: CallbackContext):
     log(update, "migrate pack")
 
     # check if there is a sticker to kang set from
-    if not update.effective_message.reply_to_message or not update.effective_message.reply_to_message.sticker:
-        update.effective_message.reply_text("Please reply to a sticker that belongs to a pack you want to migrate")
+    if (
+        not update.effective_message.reply_to_message
+        or not update.effective_message.reply_to_message.sticker
+        or update.effective_message.reply_to_message.sticker.is_animated
+    ):
+        update.effective_message.reply_text(
+            "Please reply to a non animated sticker that belongs to a pack you want to migrate"
+        )
         return
 
     # get original set name
     og_set_name = update.effective_message.reply_to_message.sticker.set_name
     if og_set_name is None:
-        update.effective_message.reply_text("Please reply to a sticker that belongs to a pack you want to migrate")
+        update.effective_message.reply_text(
+            "Please reply to a non animated sticker that belongs to a pack you want to migrate"
+        )
         return
 
     # check if the sticker set already belongs to this bot

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -330,6 +330,9 @@ def kang(update: Update, context: CallbackContext):
 def migrate(update: Update, context: CallbackContext):
     log(update, "migrate pack")
 
+    if update.effective_chat.id in get_command_exception_chats("migratepack"):
+        return
+
     # check if there is a sticker to kang set from
     if (
         not update.effective_message.reply_to_message

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -2,6 +2,7 @@ import math
 import os
 from os import remove
 from urllib.request import urlretrieve
+from uuid import uuid4
 
 from PIL import Image
 from decouple import config
@@ -151,7 +152,7 @@ def kang(update: Update, context: CallbackContext):
     # get sticker pack of user
     pack_num, pack_name = _get_pack_num_and_name(user, bot)
 
-    kang_sticker = "kang_sticker.png"
+    kang_sticker = f"{user.id}_{uuid4()}_kang_sticker.png"
 
     # If user has replied to some message
     if msg.reply_to_message:
@@ -169,7 +170,7 @@ def kang(update: Update, context: CallbackContext):
 
         # download sticker file
         kang_file = bot.get_file(file_id)
-        kang_file.download('kang_sticker.png')
+        kang_file.download(f'{user.id}_{uuid4()}_kang_sticker.png')
 
         # get emoji(s) for sticker
         if context.args:
@@ -187,7 +188,10 @@ def kang(update: Update, context: CallbackContext):
                 im.save(kang_sticker, "PNG")
 
             bot.add_sticker_to_set(
-                user_id=user.id, name=pack_name, png_sticker=open('kang_sticker.png', 'rb'), emojis=sticker_emoji
+                user_id=user.id,
+                name=pack_name,
+                png_sticker=open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'),
+                emojis=sticker_emoji,
             )
             msg.reply_markdown(
                 f"Sticker successfully added to [pack](t.me/addstickers/{pack_name})" + f"\nEmoji is: {sticker_emoji}"
@@ -199,12 +203,23 @@ def kang(update: Update, context: CallbackContext):
 
         except TelegramError as e:
             if e.message == "Stickerset_invalid":
-                _make_pack(msg, user, open('kang_sticker.png', 'rb'), sticker_emoji, bot, pack_name, pack_num)
+                _make_pack(
+                    msg,
+                    user,
+                    open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'),
+                    sticker_emoji,
+                    bot,
+                    pack_name,
+                    pack_num,
+                )
 
             elif e.message == "Sticker_png_dimensions":
                 im.save(kang_sticker, "PNG")
                 bot.add_sticker_to_set(
-                    user_id=user.id, name=pack_name, png_sticker=open('kang_sticker.png', 'rb'), emojis=sticker_emoji
+                    user_id=user.id,
+                    name=pack_name,
+                    png_sticker=open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'),
+                    emojis=sticker_emoji,
                 )
                 msg.reply_markdown(
                     f"Sticker successfully added to [pack](t.me/addstickers/{pack_name})"
@@ -236,9 +251,12 @@ def kang(update: Update, context: CallbackContext):
             im = _resize(kang_sticker)
             im.save(kang_sticker, "PNG")
 
-            msg.reply_photo(photo=open('kang_sticker.png', 'rb'))
+            msg.reply_photo(photo=open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'))
             bot.add_sticker_to_set(
-                user_id=user.id, name=pack_name, png_sticker=open('kang_sticker.png', 'rb'), emojis=sticker_emoji
+                user_id=user.id,
+                name=pack_name,
+                png_sticker=open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'),
+                emojis=sticker_emoji,
             )
             msg.reply_markdown(
                 f"Sticker successfully added to [pack](t.me/addstickers/{pack_name})" + f"\nEmoji is: {sticker_emoji}"
@@ -250,12 +268,23 @@ def kang(update: Update, context: CallbackContext):
 
         except TelegramError as e:
             if e.message == "Stickerset_invalid":
-                _make_pack(msg, user, open('kang_sticker.png', 'rb'), sticker_emoji, bot, pack_name, pack_num)
+                _make_pack(
+                    msg,
+                    user,
+                    open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'),
+                    sticker_emoji,
+                    bot,
+                    pack_name,
+                    pack_num,
+                )
 
             elif e.message == "Sticker_png_dimensions":
                 im.save(kang_sticker, "PNG")
                 bot.add_sticker_to_set(
-                    user_id=user.id, name=pack_name, png_sticker=open('kang_sticker.png', 'rb'), emojis=sticker_emoji
+                    user_id=user.id,
+                    name=pack_name,
+                    png_sticker=open(f'{user.id}_{uuid4()}_kang_sticker.png', 'rb'),
+                    emojis=sticker_emoji,
                 )
                 msg.reply_markdown(
                     f"Sticker successfully added to [pack](t.me/addstickers/{pack_name})"
@@ -293,8 +322,8 @@ def kang(update: Update, context: CallbackContext):
 
         msg.reply_markdown(reply)
 
-    if os.path.isfile("kang_sticker.png"):
-        os.remove("kang_sticker.png")
+    if os.path.isfile(f"{user.id}_{uuid4()}_kang_sticker.png"):
+        os.remove(f"{user.id}_{uuid4()}_kang_sticker.png")
 
 
 @run_async
@@ -340,14 +369,14 @@ def migrate(update: Update, context: CallbackContext):
         sticker_pack = context.bot.get_sticker_set(pack_name)
     except BadRequest:
         # download sticker
-        context.bot.get_file(stickers[0].file_id).download(f'{update.effective_user.id}_migrate_sticker.png')
+        context.bot.get_file(stickers[0].file_id).download(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png")
 
         # make pack
         try:
             _make_pack(
                 None,
                 update.effective_user,
-                open(f'{update.effective_user.id}_migrate_sticker.png', 'rb'),
+                open(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png", 'rb'),
                 stickers[0].emoji,
                 context.bot,
                 pack_name,
@@ -363,7 +392,7 @@ def migrate(update: Update, context: CallbackContext):
 
     for sticker in stickers:
         # download sticker
-        context.bot.get_file(sticker.file_id).download(f'{update.effective_user.id}_migrate_sticker.png')
+        context.bot.get_file(sticker.file_id).download(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png")
 
         # if current pack can still fit in more stickers
         if len(sticker_pack.stickers) < 120:
@@ -371,7 +400,7 @@ def migrate(update: Update, context: CallbackContext):
                 context.bot.add_sticker_to_set(
                     user_id=update.effective_user.id,
                     name=pack_name,
-                    png_sticker=open(f'{update.effective_user.id}_migrate_sticker.png', 'rb'),
+                    png_sticker=open(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png", 'rb'),
                     emojis=sticker.emoji,
                 )
             except BadRequest:
@@ -380,7 +409,7 @@ def migrate(update: Update, context: CallbackContext):
                     _make_pack(
                         None,
                         update.effective_user,
-                        open(f'{update.effective_user.id}_migrate_sticker.png', 'rb'),
+                        open(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png", 'rb'),
                         sticker.emoji,
                         context.bot,
                         pack_name,
@@ -403,7 +432,7 @@ def migrate(update: Update, context: CallbackContext):
                 _make_pack(
                     None,
                     update.effective_user,
-                    open(f'{update.effective_user.id}_migrate_sticker.png', 'rb'),
+                    open(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png", 'rb'),
                     sticker.emoji,
                     context.bot,
                     pack_name,
@@ -426,8 +455,8 @@ def migrate(update: Update, context: CallbackContext):
     update.effective_message.reply_markdown(reply)
 
     # don't want rendum files on server
-    if os.path.isfile(f'{update.effective_user.id}_migrate_sticker.png'):
-        os.remove(f'{update.effective_user.id}_migrate_sticker.png')
+    if os.path.isfile(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png"):
+        os.remove(f"{update.effective_user.id}_{uuid4()}_migrate_sticker.png")
 
 
 __help__ = r"""


### PR DESCRIPTION
To allow people to migrate all stickers from one pack to this one, so that it's easier for people to shift from other bots to neko chan as well as allowing people to kang entire packs at once