### PR TITLE
Users Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ You can set config variables in your environment, store them in a `.env` file in
 commandline arguments while running the bot.
 
 The config variables are as follows :-
+- `ADMIN` : The user ID of the person managing the bot
 - `TOKEN` : Telegram bot token
 - `DATABASE_NAME` : The name of the database you are using
 - `DATABASE_URL` : The MongoDB host URI (if not given, bot will try to connect to local MongoDB instance at default port)
 - `WEBHOOK_URL` : The URL your webhook should connect to (Default value is `False`, which will disable webhook)
 - `PORT` : Port to use for your webhooks (Default value is `80`)
 - `LOAD` : Space separated list of modules you would like to load (Default value is `False`, which will just load all modules)
-- `NO_LOAD` : Space separated list of modules you would like NOT to load (Default value is `False`, which will not skip any modules)
+- `NO_LOAD` : Space separated list of modules you would like NOT to load (Default value is `False`, which will not skip any modules
+- `SUPERUSERS` : Space separated list of user IDs for which some exceptions won't work
 
 ## Running the bot
 

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1,37 +1,52 @@
+from typing import Iterable
+
 from decouple import config
 from telegram.ext import Updater
 
 
 # class for configuration of a bot
 class Config:
-    def __init__(self, token, db_name, db_uri, webhook_url=False, port=False, load=None, no_load=None):
+    def __init__(
+        self, admin, token, db_name, db_uri, webhook_url=False, port=False, load=None, no_load=None, superusers=None
+    ):
         """
         Function to initialize the config for a bot
+        :param admin: user ID of the bot admin
         :param token: Your bot token, as a string.
         :param db_uri: Your database URL
         :param webhook_url: The URL your webhook should connect to (only needed for webhook mode)
         :param port: Port to use for your webhooks
         """
 
+        if superusers is None:
+            superusers = []
+
+        self.ADMIN = admin
         self.TOKEN = token
+
         self.DB_NAME = db_name
         self.DB_URI = db_uri
+
         self.WEBHOOK_URL = webhook_url
         self.PORT = port
 
         self.LOAD = load
         self.NO_LOAD = no_load
 
+        self.SUPERUSERS = superusers
+
 
 # create config object
 config = Config(
+    admin=config('ADMIN', cast=int),
     token=config('TOKEN'),
     db_name=config('DATABASE_NAME'),
     db_uri=config('DATABASE_URL', default=None),
     webhook_url=config('WEBHOOK_URL', default=False),
-    port=config('PORT', default=80),
+    port=config('PORT', default=80, cast=int),
     load=config('LOAD', default=False, cast=lambda x: x.split(" ") if x else False),
     no_load=config('NO_LOAD', default=False, cast=lambda x: x.split(" ") if x else False),
+    superusers=config("SUPERUSERS", default=[], cast=lambda x: map(int, x.split(" "))),
 )
 
 # create updater and dispatcher

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1,5 +1,3 @@
-from typing import Iterable
-
 from decouple import config
 from telegram.ext import Updater
 

--- a/telebot/functions.py
+++ b/telebot/functions.py
@@ -1,6 +1,6 @@
 from collections import Callable
 from functools import wraps
-from traceback import print_exc
+from traceback import print_exc, format_exc
 
 from telegram import Update
 from telegram.ext import CallbackContext
@@ -101,10 +101,10 @@ def bot_action(func_name: str = None, extra_text: str = ""):
 
             try:
                 func(update, context, *args, **kwargs)
-            except Exception as e:
+            except:
                 print_exc()
                 update.effective_message.reply_markdown(
-                    f"`{str(e.__class__)} : {str(e)}`\n\n"
+                    f"```{format_exc()}```\n\n"
                     f"Show this to {mention_markdown(user_id=config.ADMIN, name='my master')} and bribe him with some "
                     f"catnip to fix it for you..."
                 )

--- a/telebot/functions.py
+++ b/telebot/functions.py
@@ -4,7 +4,7 @@ from traceback import print_exc, format_exc
 
 from telegram import Update
 from telegram.ext import CallbackContext
-from telegram.utils.helpers import escape_markdown, mention_markdown
+from telegram.utils.helpers import mention_markdown
 
 from telebot import config
 

--- a/telebot/functions.py
+++ b/telebot/functions.py
@@ -105,7 +105,7 @@ def bot_action(func_name: str = None, extra_text: str = ""):
             except Exception as e:
                 print_exc()
                 update.effective_message.reply_markdown(
-                    f"`{escape_markdown(str(e))}`\n\n"
+                    f"`{escape_markdown(str(e.__class__))} : {escape_markdown(str(e))}`\n\n"
                     f"Show this to {mention_markdown(user_id=config.ADMIN, name='my master')} and bribe him with some "
                     f"catnip to fix it for you..."
                 )

--- a/telebot/functions.py
+++ b/telebot/functions.py
@@ -8,7 +8,6 @@ from telegram.utils.helpers import escape_markdown, mention_markdown
 
 from telebot import config
 
-
 # Some Helper Functions
 from telebot.modules.db.users import add_user
 

--- a/telebot/functions.py
+++ b/telebot/functions.py
@@ -104,7 +104,7 @@ def bot_action(func_name: str = None, extra_text: str = ""):
             except Exception as e:
                 print_exc()
                 update.effective_message.reply_markdown(
-                    f"`{escape_markdown(str(e.__class__))} : {escape_markdown(str(e))}`\n\n"
+                    f"`{str(e.__class__)} : {str(e)}`\n\n"
                     f"Show this to {mention_markdown(user_id=config.ADMIN, name='my master')} and bribe him with some "
                     f"catnip to fix it for you..."
                 )

--- a/telebot/functions.py
+++ b/telebot/functions.py
@@ -10,6 +10,7 @@ from telebot import config
 
 
 # Some Helper Functions
+from telebot.modules.db.users import add_user
 
 
 def check_user_admin(func: Callable):
@@ -94,6 +95,8 @@ def bot_action(func_name: str = None, extra_text: str = ""):
             :param kwargs: anything extra
             :return: inner function to execute
             """
+            add_user(user_id=update.effective_user.id, username=update.effective_user.username)
+
             if func_name:
                 log(update, func_name, extra_text)
 

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -9,7 +9,7 @@ from telegram.ext import run_async, CallbackContext, CommandHandler
 from telegram.utils.helpers import escape_markdown
 
 from telebot import dispatcher
-from telebot.functions import check_user_admin, check_bot_admin, log
+from telebot.functions import check_user_admin, check_bot_admin, log, bot_action
 from telebot.modules.db.exceptions import get_command_exception_chats
 from telebot.modules.db.mute import add_muted_member, fetch_muted_member, remove_muted_member
 
@@ -46,6 +46,7 @@ def can_restrict(func: Callable):
 
 
 @run_async
+@bot_action("mute")
 @check_user_admin
 @check_bot_admin
 @can_restrict
@@ -55,8 +56,6 @@ def mute(update: Update, context: CallbackContext):
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "mute")
-
     # kwargs to pass to the restrict_chat_member function call
     kwargs = {'chat_id': update.effective_chat.id}
 
@@ -126,6 +125,7 @@ def mute(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("un mute")
 @check_user_admin
 @check_bot_admin
 @can_restrict
@@ -135,8 +135,6 @@ def unmute(update: Update, context: CallbackContext):
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "un-mute")
-
     # kwargs to pass to the restrict_chat_member function call
     kwargs = {'chat_id': update.effective_chat.id}
 
@@ -182,6 +180,7 @@ def unmute(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("ban")
 @check_user_admin
 @check_bot_admin
 @can_restrict
@@ -192,7 +191,6 @@ def ban(update: Update, context: CallbackContext):
     :param context: object containing data about the command call.
     """
     action = "ban" if update.effective_message.text.split(None, 1)[0] == "/ban" else "kick"
-    log(update, action)
 
     # kwargs to pass to the ban_chat_member function call
     kwargs = {'chat_id': update.effective_chat.id}
@@ -256,6 +254,21 @@ def ban(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("kick")
+@check_user_admin
+@check_bot_admin
+@can_restrict
+def kick(update: Update, context: CallbackContext):
+    """
+    kick a user from a chat
+    :param update: object representing the incoming update.
+    :param context: object containing data about the command call.
+    """
+    ban(update, context)
+
+
+@run_async
+@bot_action("promote")
 @check_user_admin
 @check_bot_admin
 def promote(update: Update, context: CallbackContext):
@@ -282,8 +295,6 @@ def promote(update: Update, context: CallbackContext):
             "Ask your sugar daddy to give me perms required to use the method `CanPromoteMembers`."
         )
         return
-
-    log(update, "promote")
 
     # get member to promote
     if update.effective_message.reply_to_message:
@@ -321,6 +332,7 @@ def promote(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("pin")
 @check_user_admin
 @check_bot_admin
 def pin(update: Update, context: CallbackContext):
@@ -351,8 +363,6 @@ def pin(update: Update, context: CallbackContext):
         )
         return
 
-    log(update, "pin")
-
     # check if there is a message to pin
     if not update.effective_message.reply_to_message:
         update.effective_message.reply_text("I'm a cat, not a psychic! Reply to the message you want to pin...")
@@ -373,6 +383,7 @@ def pin(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("purge")
 @check_user_admin
 @check_bot_admin
 def purge(update: Update, context: CallbackContext):
@@ -399,8 +410,6 @@ def purge(update: Update, context: CallbackContext):
             "Bribe your sugar daddy with some catnip and ask him to allow me to delete messages..."
         )
         return
-
-    log(update, "purge")
 
     # check if start point is given
     if not update.effective_message.reply_to_message:
@@ -448,6 +457,6 @@ dispatcher.add_handler(CommandHandler("promote", promote))
 dispatcher.add_handler(CommandHandler("mute", mute))
 dispatcher.add_handler(CommandHandler("unmute", unmute))
 dispatcher.add_handler(CommandHandler("ban", ban))
-dispatcher.add_handler(CommandHandler("kick", ban))
+dispatcher.add_handler(CommandHandler("kick", kick))
 dispatcher.add_handler(CommandHandler("pin", pin))
 dispatcher.add_handler(CommandHandler("purge", purge))

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -9,7 +9,7 @@ from telegram.ext import run_async, CallbackContext, CommandHandler
 from telegram.utils.helpers import escape_markdown
 
 from telebot import dispatcher
-from telebot.functions import check_user_admin, check_bot_admin, log, bot_action
+from telebot.functions import check_user_admin, check_bot_admin, bot_action
 from telebot.modules.db.exceptions import get_command_exception_chats
 from telebot.modules.db.mute import add_muted_member, fetch_muted_member, remove_muted_member
 

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -164,7 +164,7 @@ def mute(update: Update, context: CallbackContext):
         until_date=kwargs['until_date'] if 'until_date' in kwargs.keys() else None,
     ):
         # mute member
-        # context.bot.restrict_chat_member(**kwargs)
+        context.bot.restrict_chat_member(**kwargs)
         reply = (
             f"Sewed up @{escape_markdown(username)}'s mouth :smiling_face_with_horns:\nIf you want to be un-muted, "
             f"bribe an admin with some catnip to do it for you..."
@@ -293,9 +293,9 @@ def ban_kick(update: Update, context: CallbackContext):
         return
 
     # ban user
-    # context.bot.kick_chat_member(**kwargs)
-    # if action == "kick":
-    #     context.bot.unban_chat_member(kwargs['chat_id'], kwargs['user_id'])
+    context.bot.kick_chat_member(**kwargs)
+    if action == "kick":
+        context.bot.unban_chat_member(kwargs['chat_id'], kwargs['user_id'])
 
     # announce ban
     reply = (
@@ -529,6 +529,6 @@ dispatcher.add_handler(CommandHandler("promote", promote))
 dispatcher.add_handler(CommandHandler("mute", mute))
 dispatcher.add_handler(CommandHandler("unmute", unmute))
 dispatcher.add_handler(CommandHandler("ban", ban))
-dispatcher.add_handler(CommandHandler("kicc", kick))
+dispatcher.add_handler(CommandHandler("kick", kick))
 dispatcher.add_handler(CommandHandler("pin", pin))
 dispatcher.add_handler(CommandHandler("purge", purge))

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -216,18 +216,8 @@ def unmute(update: Update, context: CallbackContext):
         )
         return
 
-    # set muted permissions
-    user = update.effective_chat.get_member(kwargs['user_id'])
-    kwargs['permissions'] = ChatPermissions(
-        can_send_messages=True,
-        can_send_media_messages=True,
-        can_send_other_messages=True,
-        can_send_polls=True,
-        can_add_web_page_previews=True,
-        can_change_info=user.can_change_info,
-        can_invite_users=user.can_invite_users,
-        can_pin_messages=user.can_pin_messages,
-    )
+    # set default permissions
+    kwargs['permissions'] = context.bot.get_chat(update.effective_chat.id).permissions
 
     # unmute member
     if remove_muted_member(chat=kwargs['chat_id'], user=kwargs['user_id']):

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -138,7 +138,7 @@ def unmute(update: Update, context: CallbackContext):
     # kwargs to pass to the restrict_chat_member function call
     kwargs = {'chat_id': update.effective_chat.id}
 
-    # get user to mute
+    # get user to un mute
     if update.effective_message.reply_to_message:
         kwargs['user_id'] = update.effective_message.reply_to_message.from_user.id
         username = update.effective_message.reply_to_message.from_user.username
@@ -146,6 +146,11 @@ def unmute(update: Update, context: CallbackContext):
         usernames = list(update.effective_message.parse_entities([MessageEntity.MENTION]).values())
         if usernames:
             kwargs['user_id'] = fetch_muted_member(chat=kwargs['chat_id'], username=usernames[0][1:])
+            if not kwargs['user_id']:
+                update.effective_message.reply_text(
+                    "No such user is muted in this chat... Maybe stop the catnip for a while?"
+                )
+                return
             username = usernames[0][1:]
         else:
             update.effective_message.reply_text(

--- a/telebot/modules/basics.py
+++ b/telebot/modules/basics.py
@@ -6,8 +6,8 @@ from telegram.ext import CallbackContext, CommandHandler, run_async
 from telegram.utils.helpers import escape_markdown, mention_markdown
 
 from telebot import updater, dispatcher
+from telebot.functions import log, bot_action
 from telebot.modules import imported_mods
-from telebot.functions import log
 
 # default Start Text
 START_TEXT = emojize(
@@ -21,24 +21,24 @@ I'm `{updater.bot.first_name}`, a cute little bot that does rendum shit rn.
 
 
 @run_async
-def start(update: Update, context: CallbackContext) -> None:
+@bot_action("start")
+def start(update: Update, context: CallbackContext):
     """
     Reply with the start message on running /start
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, func_name="start")
     update.message.reply_markdown(START_TEXT)
 
 
 @run_async
-def list_modules(update: Update, context: CallbackContext) -> None:
+@bot_action("list modules")
+def list_modules(update: Update, context: CallbackContext):
     """
     Reply with all the imported modules
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "list modules")
     update.effective_message.reply_markdown(
         "The list of Active Modules is as follows :\n\n`"
         + "`\n`".join(mod.__mod_name__ for mod in imported_mods.values())
@@ -47,14 +47,13 @@ def list_modules(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
-def help(update: Update, context: CallbackContext) -> None:
+@bot_action("help")
+def help(update: Update, context: CallbackContext):
     """
     Reply with help message for the specified modules
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, func_name="help")
-
     text_blob = START_TEXT + "\n_Use following commands to use me_ (*blush*):\n"
 
     if not context.args:
@@ -88,14 +87,13 @@ def help(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
+@bot_action("talk")
 def talk(update: Update, context: CallbackContext) -> None:
     """
     Repeat a given word random number of times
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, func_name="talk")
-
     # get word (meow if not given)
     word = "meow "
     if context.args:
@@ -110,27 +108,26 @@ def talk(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
+@bot_action("id")
 def get_id(update: Update, context: CallbackContext) -> None:
     """
     Function to get chat and user ID
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "id")
-
     update.effective_message.reply_markdown(
         f"Your ID is :\n`{update.effective_user.id}`\n\nThe chat ID is :\n`{update.effective_chat.id}`"
     )
 
 
+@run_async
+@bot_action("info")
 def info(update: Update, context: CallbackContext):
     """
     Function to get user details
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "info")
-
     # get user to display info of
     user: User = update.message.reply_to_message.from_user if update.message.reply_to_message else update.effective_user
 

--- a/telebot/modules/basics.py
+++ b/telebot/modules/basics.py
@@ -6,7 +6,7 @@ from telegram.ext import CallbackContext, CommandHandler, run_async
 from telegram.utils.helpers import escape_markdown, mention_markdown
 
 from telebot import updater, dispatcher
-from telebot.functions import log, bot_action
+from telebot.functions import bot_action
 from telebot.modules import imported_mods
 
 # default Start Text

--- a/telebot/modules/db/exceptions.py
+++ b/telebot/modules/db/exceptions.py
@@ -6,17 +6,17 @@ from mongoengine import Document, StringField, ListField, IntField
 
 # create models for this module
 class Exceptions(Document):
-    command = StringField(required=True)  # command for which exception is being set
+    command = StringField(required=True)  # bot_action for which exception is being set
     chats = ListField(IntField())  # list of chat IDs in which exception is being set
 
 
 # create helper functions to be used to interact with the model
 
 
-def get_command_exception_chats(command: str) -> List[int]:
+def get_command_exception_chats(bot_action: str) -> List[int]:
     """
-    Get all chats that have an exception for a given command
-    :param command: the command whose exception we're checking for
+    Get all chats that have an exception for a given bot_action
+    :param command: the bot_action whose exception we're checking for
     :return: list of chat IDs
     """
     exceptions: List[Exceptions] = Exceptions.objects(command=command)
@@ -27,35 +27,35 @@ def get_command_exception_chats(command: str) -> List[int]:
         return []
 
 
-def add_command_exception_chats(command: str, chat: int) -> str:
+def add_command_exception_chats(bot_action: str, chat: int) -> str:
     """
-    Add exception for a command in a chat
-    :param command: the command for which we're adding an exception
+    Add exception for a bot_action in a chat
+    :param command: the bot_action for which we're adding an exception
     :param chat: the chat ID in which we're adding the exception
     :return: the message to be replied to the user in Telegram
     """
     exceptions_list: List[Exceptions] = Exceptions.objects(command=command)
 
-    # if exceptions document for command exists
+    # if exceptions document for bot_action exists
     if exceptions_list:
         exceptions: Exceptions = exceptions_list[0]
         if chat in exceptions.chats:
-            return f"Exception for command `{command}` already added!"
+            return f"Exception for bot_action `{command}` already added!"
         else:
             exceptions.chats: List[int] = exceptions.chats + [chat]
             exceptions.save()
 
-    # if exceptions document doesn't exist for the command
+    # if exceptions document doesn't exist for the bot_action
     else:
         Exceptions(command=command, chats=[chat]).save()
 
-    return f"Exception for command `{command}` added!"
+    return f"Exception for bot_action `{command}` added!"
 
 
-def del_command_exception_chats(command: str, chat: int) -> str:
+def del_command_exception_chats(bot_action: str, chat: int) -> str:
     """
-    delete exception for a command in a chat
-    :param command: the command for which we're deleting an exception
+    delete exception for a bot_action in a chat
+    :param command: the bot_action for which we're deleting an exception
     :param chat: the chat ID in which we're deleting the exception
     :return: the message to be replied to the user in Telegram
     """
@@ -76,15 +76,15 @@ def del_command_exception_chats(command: str, chat: int) -> str:
                 # if there are no other chats in which this exception exists
                 exceptions.delete()
 
-            return f"Exception for command `{command}` deleted!"
+            return f"Exception for bot_action `{command}` deleted!"
 
         except ValueError:
-            # if the given chat ID isn't in the list of chats with exception for given command
-            return f"Exception for command `{command}` not added!"
+            # if the given chat ID isn't in the list of chats with exception for given bot_action
+            return f"Exception for bot_action `{command}` not added!"
 
     else:
-        # if there is no exceptions document for this command
-        return f"Exception for command `{command}` not added!"
+        # if there is no exceptions document for this bot_action
+        return f"Exception for bot_action `{command}` not added!"
 
 
 def get_exceptions_for_chat(chat: int) -> List[str]:

--- a/telebot/modules/db/exceptions.py
+++ b/telebot/modules/db/exceptions.py
@@ -13,7 +13,7 @@ class Exceptions(Document):
 # create helper functions to be used to interact with the model
 
 
-def get_command_exception_chats(bot_action: str) -> List[int]:
+def get_command_exception_chats(command: str) -> List[int]:
     """
     Get all chats that have an exception for a given bot_action
     :param command: the bot_action whose exception we're checking for
@@ -27,7 +27,7 @@ def get_command_exception_chats(bot_action: str) -> List[int]:
         return []
 
 
-def add_command_exception_chats(bot_action: str, chat: int) -> str:
+def add_command_exception_chats(command: str, chat: int) -> str:
     """
     Add exception for a bot_action in a chat
     :param command: the bot_action for which we're adding an exception
@@ -52,7 +52,7 @@ def add_command_exception_chats(bot_action: str, chat: int) -> str:
     return f"Exception for bot_action `{command}` added!"
 
 
-def del_command_exception_chats(bot_action: str, chat: int) -> str:
+def del_command_exception_chats(command: str, chat: int) -> str:
     """
     delete exception for a bot_action in a chat
     :param command: the bot_action for which we're deleting an exception

--- a/telebot/modules/db/users.py
+++ b/telebot/modules/db/users.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from mongoengine import StringField, DynamicDocument, IntField
+
+
+# create models for this module
+
+
+class User(DynamicDocument):
+    id = IntField(primary_key=True)  # ID of the user
+    username = StringField()  # username of the user
+
+    def __str__(self):
+        return f"<User {self.username} : {self.id}>"
+
+    def __repr__(self):
+        return f"<User {self.username} : {self.id}>"
+
+
+# create helper functions to be used to interact with the model
+
+
+def add_user(user_id: int, username: str):
+    """
+    Add/Update a user in the database
+    :param user_id: ID of the user we want to add
+    :param username: username of the user we want to add
+    :return:
+    """
+    User(id=user_id, username=username).save()
+
+
+def get_user(username: str) -> Optional[int]:
+    """
+    get the user ID of a user
+    :param username: username of the user who's ID we want to fetch
+    :return: ID of the user
+    """
+    user = User.objects(username=username).first()
+    if user:
+        return user.id
+    else:
+        return None

--- a/telebot/modules/exceptions.py
+++ b/telebot/modules/exceptions.py
@@ -2,7 +2,7 @@ from telegram import Update
 from telegram.ext import CommandHandler, run_async, CallbackContext
 
 from telebot import dispatcher
-from telebot.functions import log, bot_action
+from telebot.functions import bot_action
 from telebot.modules.db.exceptions import (
     add_command_exception_chats,
     del_command_exception_chats,

--- a/telebot/modules/exceptions.py
+++ b/telebot/modules/exceptions.py
@@ -2,7 +2,7 @@ from telegram import Update
 from telegram.ext import CommandHandler, run_async, CallbackContext
 
 from telebot import dispatcher
-from telebot.functions import log
+from telebot.functions import log, bot_action
 from telebot.modules.db.exceptions import (
     add_command_exception_chats,
     del_command_exception_chats,
@@ -11,50 +11,60 @@ from telebot.modules.db.exceptions import (
 
 
 @run_async
+@bot_action()
 def list_exceptions(update: Update, context: CallbackContext):
-    log(update, "list exceptions")
-
+    """
+    List all exceptions
+    :param update: object representing the incoming update.
+    :param context: object containing data about the command call.
+    """
     if update.effective_chat.type == "private":
         update.effective_message.reply_text("You can't list exceptions in private chats.")
+        return
 
+    commands = ", ".join(get_exceptions_for_chat(update.effective_chat.id))
+    if commands:
+        update.effective_message.reply_markdown(f"You have exceptions set for the following commands:\n`{commands}`")
     else:
-        commands = ", ".join(get_exceptions_for_chat(update.effective_chat.id))
-        if commands:
-            update.effective_message.reply_markdown(
-                f"You have exceptions set for the following commands:\n`{commands}`"
-            )
-        else:
-            update.effective_message.reply_text("You don't have any exceptions set!")
+        update.effective_message.reply_text("You don't have any exceptions set!")
 
 
 @run_async
+@bot_action("add exception")
 def add_exception(update: Update, context: CallbackContext):
-    log(update, "add exceptions")
-
+    """
+    Add exceptions in a chat
+    :param update: object representing the incoming update.
+    :param context: object containing data about the command call.
+    """
     if update.effective_chat.type == "private":
         update.effective_message.reply_text("You can't add exceptions in private chats.")
+        return
 
-    else:
-        for command in context.args:
-            reply = add_command_exception_chats(command, update.effective_chat.id)
-            update.effective_message.reply_markdown(reply)
+    for command in context.args:
+        reply = add_command_exception_chats(command, update.effective_chat.id)
+        update.effective_message.reply_markdown(reply)
 
 
 @run_async
+@bot_action("delete exceptions")
 def del_exception(update: Update, context: CallbackContext):
-    log(update, "delete exceptions")
-
+    """
+    Delete exceptions in a chat
+    :param update: object representing the incoming update.
+    :param context: object containing data about the command call.
+    """
     if update.effective_chat.type == "private":
         update.effective_message.reply_text("You can't delete exceptions in private chats.")
+        return
 
-    else:
-        for command in context.args:
-            reply = del_command_exception_chats(command, update.effective_chat.id)
-            update.effective_message.reply_markdown(reply)
+    for command in context.args:
+        reply = del_command_exception_chats(command, update.effective_chat.id)
+        update.effective_message.reply_markdown(reply)
 
 
 __help__ = """
-Adding an exception for a command in your chat will change it's behaviour. How it will change depends on the command.
+Adding an exception for a bot_action in your chat will change it's behaviour. How it will change depends on the bot_action.
 
 - /listexceptions : list all exceptions in chat
 

--- a/telebot/modules/filter.py
+++ b/telebot/modules/filter.py
@@ -5,13 +5,14 @@ from telegram import Update
 from telegram.ext import run_async, CallbackContext, CommandHandler, MessageHandler, Filters
 
 from telebot import dispatcher
-from telebot.functions import log
+from telebot.functions import log, bot_action
 from telebot.modules.db.exceptions import get_command_exception_chats
 from telebot.modules.db.filter import get_triggers_for_chat, add_filter, get_filter, del_filter
 
 
 @run_async
-def list_filters(update: Update, context: CallbackContext) -> None:
+@bot_action("list filters")
+def list_filters(update: Update, context: CallbackContext):
     """
     List all the filter triggers in a chat
     :param update: object representing the incoming update.
@@ -20,8 +21,6 @@ def list_filters(update: Update, context: CallbackContext) -> None:
     # check for exception
     if update.effective_chat.id in get_command_exception_chats("filter"):
         return
-
-    log(update, "filters")
 
     filters = get_triggers_for_chat(update.effective_chat.id)
     if filters:
@@ -33,7 +32,8 @@ def list_filters(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
-def add_filter_handler(update: Update, context: CallbackContext) -> None:
+@bot_action("add filter")
+def add_filter_handler(update: Update, context: CallbackContext):
     """
     Add a filter in a chat
     :param update: object representing the incoming update.
@@ -42,8 +42,6 @@ def add_filter_handler(update: Update, context: CallbackContext) -> None:
     # check for exception
     if update.effective_chat.id in get_command_exception_chats("filter"):
         return
-
-    log(update, "addfilter")
 
     # for ease of reference
     msg = update.effective_message
@@ -103,7 +101,8 @@ def add_filter_handler(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
-def del_filter_handler(update: Update, context: CallbackContext) -> None:
+@bot_action("delete filters")
+def del_filter_handler(update: Update, context: CallbackContext):
     """
     Delete a filter from the chat
     :param update: object representing the incoming update.
@@ -112,8 +111,6 @@ def del_filter_handler(update: Update, context: CallbackContext) -> None:
     # check for exception
     if update.effective_chat.id in get_command_exception_chats("filter"):
         return
-
-    log(update, "del filter")
 
     if context.args:
         # iterate over the triggers given and delete them from DB
@@ -126,6 +123,7 @@ def del_filter_handler(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
+@bot_action()
 def reply(update: Update, context: CallbackContext) -> None:
     """
     Reply when a filter is triggered

--- a/telebot/modules/memes.py
+++ b/telebot/modules/memes.py
@@ -9,30 +9,29 @@ from telegram.utils.helpers import escape_markdown
 from zalgo_text.zalgo import zalgo
 
 from telebot import dispatcher
-from telebot.functions import log
+from telebot.functions import log, bot_action
 
 
 @run_async
+@bot_action("runs")
 def runs(update: Update, context: CallbackContext) -> None:
     """
     Insulting reply whenever someone uses /runs
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "runs")
     update.effective_message.reply_markdown("I'm a cute kitty, and here we have a fat pussy.")
     update.effective_chat.send_sticker("CAACAgUAAxkBAAIJK19CjPoyyX9QwwHfNOZMnqww1hxXAALfAAPd6BozJDBFCIENpGkbBA")
 
 
 @run_async
+@bot_action("mock")
 def mock(update: Update, context: CallbackContext) -> None:
     """
     Mock a message like spongebob, and reply
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "mock")
-
     if update.effective_message.reply_to_message:
         update.effective_message.reply_to_message.reply_text(mock_text(update.effective_message.reply_to_message.text))
     else:
@@ -40,14 +39,13 @@ def mock(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
+@bot_action("zalgofy")
 def zalgofy(update: Update, context: CallbackContext) -> None:
     """
     Corrupt the way the text looks, and reply
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "zalgofy")
-
     if update.effective_message.reply_to_message:
         update.effective_message.reply_to_message.reply_text(
             zalgo().zalgofy(update.effective_message.reply_to_message.text)
@@ -57,14 +55,13 @@ def zalgofy(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
+@bot_action("owo")
 def owo(update: Update, context: CallbackContext) -> None:
     """
     Change a message to look like it was said by a moe weeb
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "owo")
-
     if not update.effective_message.reply_to_message:
         update.effective_message.reply_text(
             "Gommenye, I don't nyaruhodo what normie text you want to henshin into the moe weeb dialect"
@@ -119,14 +116,13 @@ def owo(update: Update, context: CallbackContext) -> None:
 
 
 @run_async
+@bot_action("stretch")
 def stretch(update: Update, context: CallbackContext):
     """
     Stretch the vowels in a message by a random count
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "stretch")
-
     if not update.effective_message.reply_to_message:
         update.effective_message.reply_text(
             "If you're not gonna give me a message to meme, at least give me some catnip..."
@@ -143,14 +139,13 @@ def stretch(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("vapor")
 def vapor(update: Update, context: CallbackContext):
     """
     Make a message look more ａｅｓｔｈｅｔｉｃ
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "vapor")
-
     if not context.args and not (
         update.effective_message.reply_to_message and update.effective_message.reply_to_message.text_markdown
     ):

--- a/telebot/modules/memes.py
+++ b/telebot/modules/memes.py
@@ -9,7 +9,7 @@ from telegram.utils.helpers import escape_markdown
 from zalgo_text.zalgo import zalgo
 
 from telebot import dispatcher
-from telebot.functions import log, bot_action
+from telebot.functions import bot_action
 
 
 @run_async

--- a/telebot/modules/nhentai.py
+++ b/telebot/modules/nhentai.py
@@ -8,7 +8,7 @@ from telegram.utils.helpers import escape_markdown
 from telegraph import Telegraph
 
 from telebot import dispatcher
-from telebot.functions import log
+from telebot.functions import log, bot_action
 from telebot.modules.db.exceptions import get_command_exception_chats
 
 
@@ -76,14 +76,13 @@ def get_content(content, _id):
 
 
 @run_async
+@bot_action("sauce")
 def sauce(update: Update, context: CallbackContext) -> None:
     """
     Fetch the doujin for all the sauces given by user, make telegraph article and send it to user for easy reading
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "sauce")
-
     # check if any args were given
     if not context.args:
         update.effective_message.reply_text("Please give some codes to fetch, this cat can't read your mind...")

--- a/telebot/modules/nhentai.py
+++ b/telebot/modules/nhentai.py
@@ -8,7 +8,7 @@ from telegram.utils.helpers import escape_markdown
 from telegraph import Telegraph
 
 from telebot import dispatcher
-from telebot.functions import log, bot_action
+from telebot.functions import bot_action
 from telebot.modules.db.exceptions import get_command_exception_chats
 
 

--- a/telebot/modules/notes.py
+++ b/telebot/modules/notes.py
@@ -3,12 +3,13 @@ from telegram import Update
 from telegram.ext import run_async, CallbackContext, CommandHandler, MessageHandler, Filters
 
 from telebot import dispatcher
-from telebot.functions import log, check_user_admin
+from telebot.functions import check_user_admin, bot_action
 from telebot.modules.db.exceptions import get_command_exception_chats
 from telebot.modules.db.notes import get_note, get_notes_for_chat, add_note, del_note
 
 
 @run_async
+@bot_action("get note")
 def fetch_note(update: Update, context: CallbackContext):
     """
     Fetch note
@@ -18,8 +19,6 @@ def fetch_note(update: Update, context: CallbackContext):
     # check exception
     if update.effective_chat.id in get_command_exception_chats("notes"):
         return
-
-    log(update, "get note")
 
     if update.effective_message.text[0] == "#":
         name = update.effective_message.text[1:]
@@ -50,6 +49,7 @@ def fetch_note(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("notes")
 def notes_for_chat(update: Update, context: CallbackContext):
     """
     List out all the notes in a chat
@@ -59,8 +59,6 @@ def notes_for_chat(update: Update, context: CallbackContext):
     # check exception
     if update.effective_chat.id in get_command_exception_chats("notes"):
         return
-
-    log(update, "notes")
 
     # get list of notes for the chat
     notes = get_notes_for_chat(update.effective_chat.id)
@@ -78,6 +76,7 @@ def notes_for_chat(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("add note")
 @check_user_admin
 def add_note_in_chat(update: Update, context: CallbackContext):
     """
@@ -149,6 +148,7 @@ def add_note_in_chat(update: Update, context: CallbackContext):
 
 
 @run_async
+@bot_action("delete note")
 @check_user_admin
 def del_note_in_chat(update: Update, context: CallbackContext):
     """
@@ -159,8 +159,6 @@ def del_note_in_chat(update: Update, context: CallbackContext):
     # check for exception
     if update.effective_chat.id in get_command_exception_chats("notes"):
         return
-
-    log(update, "del note")
 
     if context.args:
         # iterate over the triggers given and delete them from DB

--- a/telebot/modules/quote.py
+++ b/telebot/modules/quote.py
@@ -11,7 +11,7 @@ from telegram import Update, Message
 from telegram.ext import CommandHandler, CallbackContext, run_async
 
 from telebot import dispatcher
-from telebot.functions import log
+from telebot.functions import log, bot_action
 
 
 def _message_to_sticker(update: Update, context: CallbackContext) -> str:
@@ -292,14 +292,13 @@ def _message_to_sticker(update: Update, context: CallbackContext) -> str:
 
 
 @run_async
+@bot_action("quote")
 def quote(update: Update, context: CallbackContext):
     """
     convert message into quote and reply
     :param update: object representing the incoming update.
     :param context: object containing data about the command call.
     """
-    log(update, "quote")
-
     context.bot.send_chat_action(update.effective_chat.id, 'upload_photo')  # tell chat that a sticker is incoming
 
     # make sticker and save on disk

--- a/telebot/modules/quote.py
+++ b/telebot/modules/quote.py
@@ -11,7 +11,7 @@ from telegram import Update, Message
 from telegram.ext import CommandHandler, CallbackContext, run_async
 
 from telebot import dispatcher
-from telebot.functions import log, bot_action
+from telebot.functions import bot_action
 
 
 def _message_to_sticker(update: Update, context: CallbackContext) -> str:

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -1,20 +1,18 @@
 import math
 import os
-from collections import namedtuple
 from os import remove
 from typing import Tuple, IO, List
 from urllib.request import urlretrieve
 from uuid import uuid4
 
 from PIL import Image
-from decouple import config
 from emoji import emojize
 from telegram import Update, TelegramError, InlineKeyboardMarkup, InlineKeyboardButton, Bot, User, Message, StickerSet
 from telegram.error import BadRequest
 from telegram.ext import run_async, CallbackContext, CommandHandler, ConversationHandler, MessageHandler, Filters
 from telegram.utils.helpers import escape_markdown
 
-from telebot import dispatcher
+from telebot import dispatcher, config
 from telebot.functions import log
 from telebot.modules.db.exceptions import get_command_exception_chats
 
@@ -24,7 +22,7 @@ def sticker_id(update: Update, context: CallbackContext) -> None:
     """
     Reply with the file ID of a given sticker
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     """
     log(update, "sticker id")
 
@@ -40,7 +38,7 @@ def get_sticker(update: Update, context: CallbackContext) -> None:
     """
     Reply with the PNG image as a document for a given sticker
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     """
     log(update, "get sticker")
 
@@ -218,12 +216,12 @@ def kang(update: Update, context: CallbackContext) -> None:
     """
     Add a sticker to user's pack
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     """
     # check for exception, but skip exception if user is a superuser
-    if update.effective_user.id not in config(
-        "SUPERUSERS", cast=lambda x: map(int, x.split(","))
-    ) and update.effective_chat.id in get_command_exception_chats("kang"):
+    if update.effective_user.id not in config.SUPERUSERS and update.effective_chat.id in get_command_exception_chats(
+        "kang"
+    ):
         return
 
     log(update, "kang")
@@ -426,7 +424,7 @@ def migrate(update: Update, context: CallbackContext) -> None:
     """
     Migrate all stickers from a given pack into user's pack(s)
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     """
     log(update, "migrate pack")
 
@@ -585,7 +583,7 @@ def del_sticker(update: Update, context: CallbackContext) -> None:
     """
     Delete a sticker form one of the user's packs
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     """
     log(update, "del_sticker")
 
@@ -618,7 +616,7 @@ def packs(update: Update, context: CallbackContext):
     """
     List all the packs of a user
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     """
     log(update, "packs")
 
@@ -647,7 +645,7 @@ def reorder1(update: Update, context: CallbackContext):
     """
     First step in reordering sticker in pack - take input of sticker who's position is to be changed
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     :return: 0 if successful to move on to next step, else -1 (ConversationHandler.END)
     """
     log(update, "reorder step 1")
@@ -691,7 +689,7 @@ def reorder2(update: Update, context: CallbackContext):
     """
     Last step in reordering sticker in pack - take input of sticker which is now gonna be on the left of the reordered sticker
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     :return: 0, if wrong input is made, else -1 (ConversationHandler.END)
     """
     log(update, "reorder step 2")
@@ -738,7 +736,7 @@ def reorder_cancel(update: Update, context: CallbackContext):
     """
     Last step in reordering sticker in pack - take input of sticker which is now gonna be on the left of the reordered sticker
     :param update: object representing the incoming update.
-    :param context: object containing data about the command call.
+    :param context: object containing data about the bot_action call.
     :return: 0, if wrong input is made, else -1 (ConversationHandler.END)
     """
     log(update, "reorder cancel")


### PR DESCRIPTION
Store user's ID and username in database, so that they can be reffered to with their usernames

- shift call logging and safe execution of all bot actions to the `bot_action` wrapper
- db stuff for users
- store details of all users who use bot commands
- fix arg name in exceptions db helper functions
- no need to escape markdown inside code text
- check if someone tried to unmute an unmuted user
- give entire stacktrace in case of errors
- add ability to use username to mute
- add ability to use username to ban/kick
- make sure unmuted people have all default perms
- uncomment code commented for testing
- Optimize imports
