### PR TITLE
telebot: notes: update regex

### DIFF
--- a/telebot/modules/notes.py
+++ b/telebot/modules/notes.py
@@ -198,7 +198,7 @@ __mod_name__ = "Notes"
 
 # create handlers
 dispatcher.add_handler(CommandHandler("get", fetch_note, run_async=True))
-dispatcher.add_handler(MessageHandler(Filters.regex(r"^#[^\s]+$"), fetch_note, run_async=True))
+dispatcher.add_handler(MessageHandler(Filters.regex(r"^#[^\s].+$"), fetch_note, run_async=True))
 dispatcher.add_handler(CommandHandler("notes", notes_for_chat, run_async=True))
 dispatcher.add_handler(CommandHandler("saved", notes_for_chat, run_async=True))
 dispatcher.add_handler(CommandHandler("save", add_note_in_chat, run_async=True))


### PR DESCRIPTION
Earlier only `#notename` worked, `#notename xyz` didn't.

This change allows the latter to work as well.
Useful for cases like `#gta when`