### PR TITLE
Refactor configuration system

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -199,6 +199,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+python-dotenv = {version = ">=0.10.4", optional = true, markers = "extra == \"dotenv\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -237,6 +238,17 @@ description = "Strict separation of settings from code."
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "python-dotenv"
+version = "0.21.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-telegram-bot"
@@ -293,7 +305,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "setuptools"
@@ -429,7 +441,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.10.8"
-content-hash = "4bd3867dc629346d902466cf2d55bf7390dca653c01cac598be602f1ddbe39ce"
+content-hash = "ae7cc51d599cbd994d0f03ea510d954ee43f29ec3437a8354d95986194790888"
 
 [metadata.files]
 apscheduler = [
@@ -609,7 +621,6 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pymongo = [
-    {file = "pymongo-4.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:b9e4981a65f8500a3a46bb3a1e81b9feb45cf0b2115ad9c4f8d517326d026940"},
     {file = "pymongo-4.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1c81414b706627f15e921e29ae2403aab52e33e36ed92ed989c602888d7c3b90"},
     {file = "pymongo-4.2.0-cp310-cp310-manylinux1_i686.whl", hash = "sha256:c549bb519456ee230e92f415c5b4d962094caac0fdbcc4ed22b576f66169764e"},
     {file = "pymongo-4.2.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:70216ec4c248213ae95ea499b6314c385ce01a5946c448fb22f6c8395806e740"},
@@ -683,6 +694,10 @@ pyperclip = [
 python-decouple = [
     {file = "python-decouple-3.6.tar.gz", hash = "sha256:2838cdf77a5cf127d7e8b339ce14c25bceb3af3e674e039d4901ba16359968c7"},
     {file = "python_decouple-3.6-py3-none-any.whl", hash = "sha256:6cf502dc963a5c642ea5ead069847df3d916a6420cad5599185de6bab11d8c2e"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
+    {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
 ]
 python-telegram-bot = [
     {file = "python-telegram-bot-13.14.tar.gz", hash = "sha256:e9391d43eb1123de2677a9d24ea878a9d5327d65b2419afba653f476d26aecc3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ spongemock = "^0.3.4"
 zalgo-text = "^0.6"
 hentai = "^3.2.10"
 telegraph = "^2.1.0"
-pydantic = "^1.10.2"
+pydantic = {extras = ["dotenv"], version = "^1.10.2"}
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.8.0"

--- a/telebot/__init__.py
+++ b/telebot/__init__.py
@@ -1,67 +1,33 @@
-from decouple import config
+from pydantic import HttpUrl, BaseSettings
 from telegram.ext import Updater
 
 
 # class for configuration of a bot
-class Config:
-    def __init__(
-        self,
-        admin,
-        token,
-        db_name,
-        db_uri,
-        github_token,
-        webhook_url=False,
-        port=False,
-        load=None,
-        no_load=None,
-        preview_commands=None,
-        superusers=None,
-    ):
-        """
-        Function to initialize the config for a bot
-        :param admin: user ID of the bot admin
-        :param token: Your bot token, as a string.
-        :param db_uri: Your database URL
-        :param webhook_url: The URL your webhook should connect to (only needed for webhook mode)
-        :param port: Port to use for your webhooks
-        """
+class Config(BaseSettings):
+    ADMIN: int
+    TOKEN: str
 
-        if superusers is None:
-            superusers = []
+    DATABASE_NAME: str
+    DATABASE_URL: str
 
-        self.ADMIN = admin
-        self.TOKEN = token
+    GITHUB_TOKEN: str
 
-        self.DB_NAME = db_name
-        self.DB_URI = db_uri
+    WEBHOOK_URL: HttpUrl | None
+    PORT: int = 80
 
-        self.GITHUB_TOKEN = github_token
+    LOAD: list = []
+    NO_LOAD: list = []
 
-        self.WEBHOOK_URL = webhook_url
-        self.PORT = port
+    PREVIEW_COMMANDS: list = []
 
-        self.LOAD = load
-        self.NO_LOAD = no_load
-        self.PREVIEW_COMMANDS = preview_commands
+    SUPERUSERS: list[int] = []
 
-        self.SUPERUSERS = superusers
+    class Config:
+        env_file = ".env"
 
 
 # create config object
-config = Config(
-    admin=config("ADMIN", cast=int),
-    token=config("TOKEN"),
-    db_name=config("DATABASE_NAME"),
-    db_uri=config("DATABASE_URL", default=None),
-    github_token=config("GITHUB_TOKEN"),
-    webhook_url=config("WEBHOOK_URL", default=False),
-    port=config("PORT", default=80, cast=int),
-    load=config("LOAD", default=False, cast=lambda x: x.split(" ") if x else False),
-    no_load=config("NO_LOAD", default=False, cast=lambda x: x.split(" ") if x else False),
-    preview_commands=config("PREVIEW_COMMANDS", default=[], cast=lambda x: x.split(" ") if x else []),
-    superusers=config("SUPERUSERS", default=[], cast=lambda x: map(int, x.split(" "))),
-)
+config = Config()
 
 # create updater and dispatcher
 updater = Updater(config.TOKEN, use_context=True)

--- a/telebot/__main__.py
+++ b/telebot/__main__.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     updater.bot.set_my_commands(bot_commands)
 
     # connect to database
-    connect(config.DB_NAME, "default", host=config.DB_URI)
+    connect(config.DATABASE_NAME, "default", host=config.DATABASE_URL)
 
     # start bot
     if config.WEBHOOK_URL:


### PR DESCRIPTION
Make use of pydantic's BaseSettings to read environment variables
This allows us to reduce the code required for this, as well as clean it up a bit

The only change required in the existing deployment will be migrating things like LOAD, NO_LOAD, SUPERUSERS to be an actual list in the deployment configuration

- chore(deps): add in pydantic[dotenv]
- refactor(telebot): switch to using pydantic's BaseSettings for configuration
