### PR TITLE
Some code cleanups

### DIFF
--- a/telebot/modules/__init__.py
+++ b/telebot/modules/__init__.py
@@ -1,5 +1,5 @@
 import glob
-import importlib
+from importlib import import_module
 from os.path import dirname, basename, isfile
 
 from telegram import BotCommand
@@ -20,7 +20,7 @@ for module_name in ALL_MODULES:
     if (config.LOAD and module_name not in config.LOAD) or (config.NO_LOAD and module_name in config.NO_LOAD):
         continue
 
-    imported_module = importlib.import_module("telebot.modules." + module_name)
+    imported_module = import_module("telebot.modules." + module_name)
 
     # add imported module to the dict of modules, to be used later
     if not hasattr(imported_module, "__mod_name__"):

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -98,12 +98,7 @@ def get_datetime_form_args(args: List[str], username: str = "") -> Optional[date
     """
 
     # get all args other than the username
-    useful_args = []
-    for arg in args:
-        if username not in arg:
-            useful_args.append(arg)
-
-    if useful_args:
+    if useful_args := [arg for arg in args if username not in arg]:
         # get datetime till when we have to mute user
         time, unit = float(useful_args[0][:-1]), useful_args[0][-1]
         match unit:
@@ -430,12 +425,7 @@ def promote(update: Update, context: CallbackContext):
         reply += f"Everyone say NyaHello to {mention_markdown(user_id, username)}, our new admin!"
 
         # get all args other than the username
-        useful_args = []
-        for arg in context.args:
-            if username not in arg:
-                useful_args.append(arg)
-
-        if useful_args:
+        if useful_args := [arg for arg in context.args if username not in arg]:
             title = " ".join(useful_args)
             context.bot.set_chat_administrator_custom_title(update.effective_chat.id, user_id, title)
             reply += f"\nThey have been granted the title of `{title}`."

--- a/telebot/modules/admin.py
+++ b/telebot/modules/admin.py
@@ -633,7 +633,7 @@ __exception_desc__ = (
     "individual permissions."
 )
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="enable",
         args="<commands>",
@@ -702,7 +702,7 @@ __commands__ = [
         description="kick a user from the chat (whose username you've given as argument, or whose message you are quoting)",
         is_admin=True,
     ),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("promote", promote, run_async=True))

--- a/telebot/modules/basics.py
+++ b/telebot/modules/basics.py
@@ -197,7 +197,8 @@ __commands__ = (
     CommandDescription(
         command="id",
         args="[<reply|username>]",
-        description="Get details of current chat and a user (by replying to their message or giving their username) or yourself",
+        description="Get details of current chat and a user (by replying to their message or giving their username) "
+                    "or yourself",
     ),
     CommandDescription(
         command="fileid", args="<reply|username>", description="Get file ID of the file in the quoted message"

--- a/telebot/modules/basics.py
+++ b/telebot/modules/basics.py
@@ -185,7 +185,7 @@ def info(update: Update, context: CallbackContext):
 
 __mod_name__ = "Basics"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="help", args="[<modules list>]", description="Display the help text to understand how to use this bot"
     ),
@@ -202,7 +202,7 @@ __commands__ = [
     CommandDescription(
         command="fileid", args="<reply|username>", description="Get file ID of the file in the quoted message"
     ),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("start", start, run_async=True))

--- a/telebot/modules/basics.py
+++ b/telebot/modules/basics.py
@@ -198,7 +198,7 @@ __commands__ = (
         command="id",
         args="[<reply|username>]",
         description="Get details of current chat and a user (by replying to their message or giving their username) "
-                    "or yourself",
+        "or yourself",
     ),
     CommandDescription(
         command="fileid", args="<reply|username>", description="Get file ID of the file in the quoted message"

--- a/telebot/modules/delete.py
+++ b/telebot/modules/delete.py
@@ -149,10 +149,10 @@ __exception_desc__ = (
     "permission to delete messages."
 )
 
-__commands__ = [
+__commands__ = (
     CommandDescription(command="del", args="<reply>", description="delete the quoted message"),
     CommandDescription(command="purge", args="<reply> [silent|quiet]", description="delete the quoted message"),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("del", delete, run_async=True))

--- a/telebot/modules/exceptions.py
+++ b/telebot/modules/exceptions.py
@@ -68,7 +68,7 @@ def del_exception(update: Update, context: CallbackContext):
 
 __mod_name__ = "Exceptions"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(command="exceptions", description="list all exceptions in chat"),
     CommandDescription(
         command="except",
@@ -82,7 +82,7 @@ __commands__ = [
         description="Delete exceptions for given commands (space separated)",
         is_admin=True,
     ),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("exceptions", list_exceptions, run_async=True))

--- a/telebot/modules/filter.py
+++ b/telebot/modules/filter.py
@@ -200,7 +200,7 @@ __exception_desc__ = (
     "Adding exceptions for individual commands has no effect."
 )
 
-__commands__ = [
+__commands__ = (
     CommandDescription(command="filters", description="list all active filters in the chat"),
     CommandDescription(
         command="filter",
@@ -214,7 +214,7 @@ __commands__ = [
         description="delete active filters; give all filters to delete seperated by a space",
         is_admin=True,
     ),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("filters", list_filters, run_async=True))

--- a/telebot/modules/memes.py
+++ b/telebot/modules/memes.py
@@ -89,7 +89,7 @@ def owo(update: Update, context: CallbackContext) -> None:
         :return: owo-fied text
         """
         # list of all kaomojis to use in owo
-        kaomoji = [
+        kaomoji = (
             r"`(・\`ω´・)`",
             "`;;w;;`",
             "`owo`",
@@ -105,7 +105,7 @@ def owo(update: Update, context: CallbackContext) -> None:
             "`(♥_♥)`",
             "`*(^O^)*`",
             "`((+_+))`",
-        ]
+        )
 
         # replace certain characters and add a kaomoji
         reply_text = sub(r"[rl]", "w", text)

--- a/telebot/modules/memes.py
+++ b/telebot/modules/memes.py
@@ -266,7 +266,7 @@ __help__ = """
 
 __mod_name__ = "memes"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(command="mock", args="<reply|message>", description="MoCk LikE sPOnGEbob"),
     CommandDescription(
         command="zalgofy", args="<reply|message>", description="ͩ͠o̴͕r͌̈ȓ͡ṵ̠p̟͜tͯ͞ t̷͂ḣ͞ȩ͗ t̪̉e̢̪x̨͑t̼ͨ"
@@ -275,7 +275,7 @@ __commands__ = [
     CommandDescription(command="stretch", args="<reply|message>", description="talk like the sloth from zootopia"),
     CommandDescription(command="vapor", args="<reply|message>", description="ｖａｐｏｒｗａｖｅ ａｅｓｔｈｅｔｉｃｓ"),
     CommandDescription(command="sadge", args="<reply>", description="try getting over it"),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("runs", runs, run_async=True))

--- a/telebot/modules/nhentai.py
+++ b/telebot/modules/nhentai.py
@@ -116,7 +116,7 @@ def sauce(update: Update, context: CallbackContext) -> None:
 
 __mod_name__ = "nhentai"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="sauce",
         args="<digits list>",
@@ -125,8 +125,8 @@ __commands__ = [
             "You can give multiple codes, and it will fetch all those doujins.\n"
             "If you don't have an exception set for `sauc in your chat, it'll send it to you in your private chat."
         ),
-    )
-]
+    ),
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("sauce", sauce, run_async=True))

--- a/telebot/modules/nhentai.py
+++ b/telebot/modules/nhentai.py
@@ -123,7 +123,7 @@ __commands__ = (
         description=(
             "Read a doujin from nhentai.net in telegram instant preview by giving it's code.\n"
             "You can give multiple codes, and it will fetch all those doujins.\n"
-            "If you don't have an exception set for `sauc in your chat, it'll send it to you in your private chat."
+            "If you don't have an exception set for `sauce` in your chat, it'll send it to you in your private chat."
         ),
     ),
 )

--- a/telebot/modules/notes.py
+++ b/telebot/modules/notes.py
@@ -206,7 +206,7 @@ __exception_desc__ = (
     "Adding exceptions for individual commands has no effect."
 )
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="get",
         args="<note name>",
@@ -220,7 +220,7 @@ __commands__ = [
         is_admin=True,
     ),
     CommandDescription(command="clear", args="<note name>", description="clear note with this name", is_admin=True),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("get", fetch_note, run_async=True))

--- a/telebot/modules/quote.py
+++ b/telebot/modules/quote.py
@@ -327,11 +327,11 @@ def quote(update: Update, context: CallbackContext):
 
 __mod_name__ = "quote"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="quote", args="<reply>", description="reply to a message to get it's quote as a sticker"
     ),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("quote", quote, run_async=True))

--- a/telebot/modules/quote.py
+++ b/telebot/modules/quote.py
@@ -59,7 +59,7 @@ def _message_to_sticker(update: Update, context: CallbackContext) -> str:
         :return: name of user, message to be quoted and assigned color
         """
         # List consisting tuples of RGB for random color generation similar to telegram
-        head_tg = [
+        head_tg = (
             (238, 73, 40),
             (65, 169, 3),
             (224, 150, 2),
@@ -68,7 +68,7 @@ def _message_to_sticker(update: Update, context: CallbackContext) -> str:
             (252, 67, 128),
             (0, 161, 196),
             (235, 112, 2),
-        ]
+        )
         assigned_color = random.choice(head_tg)
 
         # Get Name and message quote

--- a/telebot/modules/quote.py
+++ b/telebot/modules/quote.py
@@ -41,7 +41,7 @@ def _message_to_sticker(update: Update, context: CallbackContext) -> str:
             initials = ls[0][0]
         # Generate a temp profile picture similar to telegram
         font_bold = ImageFont.truetype(join(BASE_DIR, "Fonts", "LucidaGrandeBold.ttf"), size=60, encoding="unic")
-        img = Image.new("RGB", (160, 160), color=(assigned_color))
+        img = Image.new("RGB", (160, 160), color=assigned_color)
         draw = ImageDraw.Draw(img)
         # put the initials in centre of image
         text_width, text_height = draw.textsize(initials, font_bold)

--- a/telebot/modules/regex.py
+++ b/telebot/modules/regex.py
@@ -89,7 +89,7 @@ __mod_name__ = "Regex"
 
 __exception_desc__ = f"Add an exception to `regex` to disable this module."
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="`s/<text1>/<text2>[/<flags>]`",
         description=(
@@ -101,8 +101,8 @@ __commands__ = [
             "these characters, make sure you escape them! eg: \\?."
         ),
         is_slash_command=False,
-    )
-]
+    ),
+)
 
 # ad handlers
 dispatcher.add_handler(MessageHandler(Filters.regex(compile("^s([/:|_]).*([/:|_]).*")), regex, run_async=True))

--- a/telebot/modules/regex.py
+++ b/telebot/modules/regex.py
@@ -93,12 +93,12 @@ __commands__ = (
     CommandDescription(
         command="`s/<text1>/<text2>[/<flags>]`",
         description=(
-            "Reply to a message with this to perform a sed operation on that message, replacing all occurrences of 'text1' "
-            "with 'text2'. Flags are optional, and currently include 'i' for ignore case, 'g' for global, or nothing. "
-            "Delimiters include `/`, `_`, `|`, and `:`. Text grouping is supported. The resulting message cannot be larger "
-            f"than {MAX_MESSAGE_LENGTH} characters.\n\n"
-            "*Reminder:* Sed uses some special characters to make matching easier, such as these: `+*.?\\` If you want to use "
-            "these characters, make sure you escape them! eg: \\?."
+            "Reply to a message with this to perform a sed operation on that message, replacing all occurrences of "
+            "'text1' with 'text2'. Flags are optional, and currently include 'i' for ignore case, 'g' for global, "
+            "or nothing. Delimiters include `/`, `_`, `|`, and `:`. Text grouping is supported. The resulting message "
+            f"cannot be larger than {MAX_MESSAGE_LENGTH} characters.\n\n *Reminder:* Sed uses some special characters "
+            f"to make matching easier, such as these: `+*.?\\` If you want to use these characters, make sure you "
+            f"escape them! eg: \\?. "
         ),
         is_slash_command=False,
     ),

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -799,7 +799,7 @@ def reorder_cancel(update: Update, context: CallbackContext):
 
 __mod_name__ = "Stickers"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="kang",
         args="<reply> [<emojis>]",
@@ -839,7 +839,7 @@ __commands__ = [
         args="<reply>",
         description="reply to a sticker (animated or non animated) to me to tell you its file ID",
     ),
-]
+)
 
 # create handlers
 dispatcher.add_handler(CommandHandler("stickerid", sticker_id, run_async=True))

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -821,7 +821,7 @@ __commands__ = (
         command="delsticker",
         args="<reply>",
         description="reply to a sticker (animated or non animated) belonging to a pack made by me to remove it from "
-                    "said pack",
+        "said pack",
     ),
     CommandDescription(
         command="reorder",

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -757,10 +757,11 @@ def reorder2(update: Update, context: CallbackContext):
     # get position of sticker in sticker pack
     old_index = new_index = -1
     pack = context.bot.get_sticker_set(set_name)
+    user_chat = reorder[str(update.effective_user.id) + str(update.effective_chat.id)]
     for i, s in enumerate(pack.stickers):
         if s.file_id == sticker.file_id:
             new_index = i
-        elif s.file_id == reorder[str(update.effective_user.id) + str(update.effective_chat.id)]:
+        elif s.file_id == user_chat:
             old_index = i
         if -1 not in (new_index, old_index):
             break

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -819,7 +819,8 @@ __commands__ = (
     CommandDescription(
         command="delsticker",
         args="<reply>",
-        description="reply to a sticker (animated or non animated) belonging to a pack made by me to remove it from said pack",
+        description="reply to a sticker (animated or non animated) belonging to a pack made by me to remove it from "
+                    "said pack",
     ),
     CommandDescription(
         command="reorder",

--- a/telebot/modules/stickers.py
+++ b/telebot/modules/stickers.py
@@ -579,7 +579,7 @@ def migrate(update: Update, context: CallbackContext) -> None:
                     case "Stickers_too_much":
                         print(len(sticker_pack.stickers))
 
-            # updsate sticker pack
+            # update sticker pack
             sticker_pack = context.bot.get_sticker_set(pack_name)
 
         # if current pack is full

--- a/telebot/modules/ud.py
+++ b/telebot/modules/ud.py
@@ -38,10 +38,10 @@ def ud(update: Update, context: CallbackContext):
 
 __mod_name__ = "Urban-Dictionary"
 
-__commands__ = [
+__commands__ = (
     CommandDescription(
         command="ud", args="<word>", description="search what the word means according to urban dictionary"
     ),
-]
+)
 
 dispatcher.add_handler(CommandHandler("ud", ud, run_async=True))


### PR DESCRIPTION
Random cleanups based on IDE warnings, and some stuff suggested by [perflint](https://github.com/tonybaloney/perflint)

- fix(perflint): W8301: Use tuple instead of list for a non-mutated sequence (use-tuple-over-list)
- fix: missing backtick
- fix(help): some strings were >120 chars
- chore(stickers): get value once outside the loop, instead of in every iteration
- chore(quote): drop unneeded parantheses
- chore(quote): W8301: Use tuple instead of list for a non-mutated sequence (use-tuple-over-list)
- chore(stickers): fix spelling
- chore(modules): Importing the "import_module" name directly is more efficient in this loop. (dotted-import-in-loop)
- chore(memes): W8301: Use tuple instead of list for a non-mutated sequence (use-tuple-over-list)
- chore(admin): W8401: Use a list comprehension instead of a for-loop (use-list-comprehension)
